### PR TITLE
1.21.1 - Added MariaDB Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# GriefLogger-MariaDB
+
+This repository is a fork of GriefLogger with MariaDB support added.
+
+## New configuration option
+
+A new configuration entry was added under `database` to choose which remote SQL driver to use when `useMysql` is enabled.
+
+- `database.useMysql` (boolean) — When `true`, GriefLogger will use a remote SQL database instead of the bundled SQLite file. When `false`, SQLite (`database.db`) is used.
+- `database.sqlDriver` (string) — Selects the remote JDBC driver to use. Allowed values:
+  - `"mysql"` — Use the official MySQL Connector/J (`com.mysql:mysql-connector-j`). This is the default.
+  - `"mariadb"` — Use the MariaDB JDBC driver (`org.mariadb.jdbc:mariadb-java-client`).
+
+When using `useMysql: true`, set `database.sqlDriver` accordingly and provide the usual connection settings:
+
+- `database.mysqlHost` (string)
+- `database.mysqlPort` (int)
+- `database.mysqlDatabase` (string)
+- `database.mysqlUsername` (string)
+- `database.mysqlPassword` (string)
+- `database.mysqlTimeout` (int: milliseconds)
+
+Example (YAML):
+
+```yaml
+database:
+  useMysql: true
+  sqlDriver: "mariadb"
+  mysqlHost: "db.example.org"
+  mysqlPort: 3306
+  mysqlDatabase: "grieflogger"
+  mysqlUsername: "grief"
+  mysqlPassword: "secret"
+  mysqlTimeout: 5000
+```
+
+## Build notes
+
+Both MySQL and MariaDB JDBC drivers are included in the relevant platform modules (`fabric` and `neoforge`) so you can switch drivers without changing the code. The Gradle build will produce shaded jars as configured in each subproject.
+
+To build on Windows PowerShell (project root):
+
+```powershell
+.\gradlew.bat build
+```
+
+If you want me to run the build now and report results, confirm and I'll start it.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## Changes
+
+### Added
+- MariaDB database driver support
+- New configuration option `database.sqlDriver` to choose between MySQL and MariaDB drivers
+- MariaDB JDBC driver included in build artifacts
+
+### Changed
+- Updated database configuration comments to reflect MySQL/MariaDB support
+- Improved connection string handling for multiple SQL drivers
+
+### Removed
+- Automatic uploads to CurseForge and Modrinth (can be re-enabled manually)
+
 ## [View changes here](https://github.com/DAQEM/GriefLogger/releases)
 
 [![BisectHosting code DAQEM for 25% off!](https://www.bisecthosting.com/partners/custom-banners/bb6b0cc7-75a1-4002-9257-561d8df48142.webp)](https://bisecthosting.com/DAQEM?r=GriefLogger+Changelog)

--- a/common/src/main/java/com/daqem/grieflogger/config/GriefLoggerConfig.java
+++ b/common/src/main/java/com/daqem/grieflogger/config/GriefLoggerConfig.java
@@ -13,6 +13,7 @@ public class GriefLoggerConfig {
     }
 
     public static final Supplier<Boolean> useMysql;
+    public static final Supplier<String> sqlDriver;
     public static final Supplier<String> mysqlHost;
     public static final Supplier<Integer> mysqlPort;
     public static final Supplier<String> mysqlDatabase;
@@ -31,13 +32,14 @@ public class GriefLoggerConfig {
     static {
         IConfigBuilder config = ConfigBuilders.newTomlConfig(GriefLogger.MOD_ID, GriefLogger.MOD_ID, true);
         config.push("database");
-        useMysql = config.comment("Whether to use MySQL or SQLite").onlyOnServer().define("useMysql", false);
-        mysqlHost = config.comment("MySQL host").onlyOnServer().define("mysqlHost", "localhost", 1, 255);
-        mysqlPort = config.comment("MySQL port").onlyOnServer().define("mysqlPort", 3306, 1, 65535);
-        mysqlDatabase = config.comment("MySQL database").onlyOnServer().define("mysqlDatabase", "database", 1, 255);
-        mysqlUsername = config.comment("MySQL username").onlyOnServer().define("mysqlUsername", "username", 1, 255);
-        mysqlPassword = config.comment("MySQL password").onlyOnServer().define("mysqlPassword", "password", 1, 255);
-        mysqlTimeout = config.comment("MySQL timeout").onlyOnServer().define("mysqlTimeout", 5000, 1, 60000);
+        useMysql = config.comment("Whether to use MySQL/MariaDB or SQLite").onlyOnServer().define("useMysql", false);
+        sqlDriver = config.comment("SQL driver to use when useMysql is true (mysql or mariadb)").onlyOnServer().define("sqlDriver", "mysql", 1, 10);
+        mysqlHost = config.comment("MySQL/MariaDB host").onlyOnServer().define("mysqlHost", "localhost", 1, 255);
+        mysqlPort = config.comment("MySQL/MariaDB port").onlyOnServer().define("mysqlPort", 3306, 1, 65535);
+        mysqlDatabase = config.comment("MySQL/MariaDB database").onlyOnServer().define("mysqlDatabase", "database", 1, 255);
+        mysqlUsername = config.comment("MySQL/MariaDB username").onlyOnServer().define("mysqlUsername", "username", 1, 255);
+        mysqlPassword = config.comment("MySQL/MariaDB password").onlyOnServer().define("mysqlPassword", "password", 1, 255);
+        mysqlTimeout = config.comment("MySQL/MariaDB timeout").onlyOnServer().define("mysqlTimeout", 5000, 1, 60000);
         useIndexes = config.comment("Whether to use indexes (improves inspect/lookup speed)").onlyOnServer().define("useIndexes", true);
         config.pop();
 

--- a/common/src/main/java/com/daqem/grieflogger/database/Database.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/Database.java
@@ -57,18 +57,29 @@ public class Database {
         String database = GriefLoggerConfig.mysqlDatabase.get();
         String user = GriefLoggerConfig.mysqlUsername.get();
         String password = GriefLoggerConfig.mysqlPassword.get();
-        String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?allowReconnect=true&autoReconnect=true&connectTimeout=" + GriefLoggerConfig.mysqlTimeout.get();
+        String sqlDriver = GriefLoggerConfig.sqlDriver.get().toLowerCase();
+
+        String url;
+        String driverClass;
+
+        if ("mariadb".equals(sqlDriver)) {
+            url = "jdbc:mariadb://" + host + ":" + port + "/" + database + "?allowReconnect=true&autoReconnect=true&connectTimeout=" + GriefLoggerConfig.mysqlTimeout.get();
+            driverClass = "org.mariadb.jdbc.Driver";
+        } else {
+            url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?allowReconnect=true&autoReconnect=true&connectTimeout=" + GriefLoggerConfig.mysqlTimeout.get();
+            driverClass = "com.mysql.cj.jdbc.Driver";
+        }
 
         try {
-            Class.forName("com.mysql.cj.jdbc.Driver");
+            Class.forName(driverClass);
         } catch (ClassNotFoundException e) {
-            GriefLogger.LOGGER.error("Failed to load MySQL driver", e);
+            GriefLogger.LOGGER.error("Failed to load " + sqlDriver + " driver", e);
             return false;
         }
         try {
             connection = DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
-            GriefLogger.LOGGER.error("Failed to connect to MySQL database", e);
+            GriefLogger.LOGGER.error("Failed to connect to " + sqlDriver + " database", e);
             return false;
         }
         return connection != null;

--- a/common/src/main/java/com/daqem/grieflogger/database/queue/Queue.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/queue/Queue.java
@@ -36,8 +36,11 @@ public class Queue implements IQueue {
     @Override
     public void hello() {
         try {
-            PreparedStatement statement = this.database.prepareStatement("SELECT 1");
-            this.database.execute(statement.toString(), false);
+            // Execute a simple test query to verify the connection.
+            // Passing PreparedStatement.toString() caused the driver to receive
+            // a string like "ClientPreparedStatement{sql:'SELECT 1', parameters:[]}"
+            // which is not valid SQL. Use the raw SQL string instead.
+            this.database.execute("SELECT 1", false);
         } catch (Exception e) {
             GriefLogger.LOGGER.error("Failed to send hello packet", e);
         }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     modImplementation "com.mysql:mysql-connector-j:8.4.0"
     shadowBundle "com.mysql:mysql-connector-j:8.4.0"
 
+    modImplementation "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+    shadowBundle "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+
     modImplementation "curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file_fabric}"
 }
 
@@ -71,52 +74,4 @@ remapJar {
 
 remapSourcesJar {
     archiveClassifier = "fabric-sources"
-}
-
-curseforge {
-    apiKey = System.getenv('CURSEFORGE_API_KEY')
-    project {
-        id = project.curse_forge_project_id
-        releaseType = project.curse_forge_release_type
-        changelogType = "markdown"
-        changelog = rootProject.file('changelog.md')
-        addGameVersion project.minecraft_version
-        addGameVersion "Java 21"
-        addGameVersion "Fabric"
-
-        relations {
-            requiredDependency("architectury-api")
-            requiredDependency("supermartijn642s-config-lib")
-        }
-
-        mainArtifact(remapJar) {
-            displayName = "GriefLogger Fabric $project.minecraft_version - $project.mod_version"
-        }
-
-        addArtifact(remapSourcesJar) {
-        }
-    }
-    options {
-        forgeGradleIntegration = false
-    }
-}
-
-afterEvaluate {
-    tasks.curseforge435029.dependsOn remapJar
-}
-
-modrinth {
-    token = System.getenv("MODRINTH_API_KEY")
-    projectId = "8oGVUFuX"
-    versionName = "GriefLogger Fabric $rootProject.minecraft_version - $rootProject.mod_version"
-    versionNumber = "$rootProject.mod_version"
-    versionType = "$rootProject.curse_forge_release_type"
-    uploadFile = remapJar
-    additionalFiles = [remapSourcesJar]
-    gameVersions = ["$rootProject.minecraft_version"]
-    loaders = ["fabric"]
-    dependencies {
-        required.project "architectury-api"
-        required.project "supermartijn642s-config-lib"
-    }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -35,14 +35,36 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowBundle project(path: ":common", configuration: "transformProductionFabric")
 
-    modImplementation "org.xerial:sqlite-jdbc:3.47.2.0"
-    shadowBundle "org.xerial:sqlite-jdbc:3.47.2.0"
+    modImplementation("org.xerial:sqlite-jdbc:3.47.2.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+    }
+    shadowBundle("org.xerial:sqlite-jdbc:3.47.2.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+    }
 
-    modImplementation "com.mysql:mysql-connector-j:8.4.0"
-    shadowBundle "com.mysql:mysql-connector-j:8.4.0"
+    modImplementation("com.mysql:mysql-connector-j:8.4.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
+    shadowBundle("com.mysql:mysql-connector-j:8.4.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
 
-    modImplementation "org.mariadb.jdbc:mariadb-java-client:3.4.1"
-    shadowBundle "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+    modImplementation("org.mariadb.jdbc:mariadb-java-client:3.4.1") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
+    shadowBundle("org.mariadb.jdbc:mariadb-java-client:3.4.1") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
 
     modImplementation "curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file_fabric}"
 }
@@ -62,9 +84,17 @@ processResources {
 shadowJar {
     exclude "architectury.common.json"
     exclude "org/slf4j/**"
+    exclude "org/checkerframework/**"
+    exclude "com/sun/jna/**"
+    exclude "com/google/errorprone/**"
+    exclude "javax/annotation/**"
 
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = "dev-shadow"
+    
+    relocate 'com.sun.jna', 'grieflogger.hidden.com.sun.jna'
+    relocate 'com.google.errorprone', 'grieflogger.hidden.com.google.errorprone'
+    relocate 'org.checkerframework', 'grieflogger.hidden.org.checkerframework'
 }
 
 remapJar {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -41,14 +41,36 @@ dependencies {
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':common', configuration: 'transformProductionNeoForge')
 
-    modImplementation "org.xerial:sqlite-jdbc:3.47.2.0"
-    shadowBundle "org.xerial:sqlite-jdbc:3.47.2.0"
+    modImplementation("org.xerial:sqlite-jdbc:3.47.2.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+    }
+    shadowBundle("org.xerial:sqlite-jdbc:3.47.2.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+    }
 
-    modImplementation "com.mysql:mysql-connector-j:8.4.0"
-    shadowBundle "com.mysql:mysql-connector-j:8.4.0"
+    modImplementation("com.mysql:mysql-connector-j:8.4.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
+    shadowBundle("com.mysql:mysql-connector-j:8.4.0") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
 
-    modImplementation "org.mariadb.jdbc:mariadb-java-client:3.4.1"
-    shadowBundle "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+    modImplementation("org.mariadb.jdbc:mariadb-java-client:3.4.1") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
+    shadowBundle("org.mariadb.jdbc:mariadb-java-client:3.4.1") {
+        exclude group: "org.checkerframework"
+        exclude group: "com.google.errorprone"
+        exclude group: "com.sun.jna"
+    }
 
     modImplementation "curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file_neoforge}"
 }
@@ -68,9 +90,17 @@ processResources {
 shadowJar {
     exclude "architectury.common.json"
     exclude "org/slf4j/**"
+    exclude "org/checkerframework/**"
+    exclude "com/sun/jna/**"
+    exclude "com/google/errorprone/**"
+    exclude "javax/annotation/**"
 
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = "neoforge-dev-shadow"
+    
+    relocate 'com.sun.jna', 'grieflogger.hidden.com.sun.jna'
+    relocate 'com.google.errorprone', 'grieflogger.hidden.com.google.errorprone'
+    relocate 'org.checkerframework', 'grieflogger.hidden.org.checkerframework'
 }
 
 remapJar {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     modImplementation "com.mysql:mysql-connector-j:8.4.0"
     shadowBundle "com.mysql:mysql-connector-j:8.4.0"
 
+    modImplementation "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+    shadowBundle "org.mariadb.jdbc:mariadb-java-client:3.4.1"
+
     modImplementation "curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file_neoforge}"
 }
 
@@ -77,45 +80,4 @@ remapJar {
 
 remapSourcesJar {
     archiveClassifier = "neoforge-sources"
-}
-
-curseforge {
-    apiKey = System.getenv("CURSEFORGE_API_KEY")
-    project {
-        id = project.curse_forge_project_id
-        releaseType = project.curse_forge_release_type
-        changelogType = "markdown"
-        changelog = rootProject.file('changelog.md')
-        addGameVersion project.minecraft_version
-        addGameVersion "Java 21"
-        addGameVersion "NeoForge"
-
-        relations {
-            requiredDependency("architectury-api")
-            requiredDependency("supermartijn642s-config-lib")
-        }
-
-        mainArtifact(remapJar) {
-            displayName = "GriefLogger NeoForge $project.minecraft_version - $project.mod_version"
-        }
-
-        addArtifact(remapSourcesJar) {
-        }
-    }
-}
-
-modrinth {
-    token = System.getenv("MODRINTH_API_KEY")
-    projectId = "8oGVUFuX"
-    versionName = "GriefLogger NeoForge $rootProject.minecraft_version - $rootProject.mod_version"
-    versionNumber = "$rootProject.mod_version"
-    versionType = "$rootProject.curse_forge_release_type"
-    uploadFile = remapJar
-    additionalFiles = [remapSourcesJar]
-    gameVersions = ["$rootProject.minecraft_version"]
-    loaders = ["neoforge"]
-    dependencies {
-        required.project "architectury-api"
-        required.project "supermartijn642s-config-lib"
-    }
 }


### PR DESCRIPTION
### Added
- MariaDB database driver support
- New configuration option `database.sqlDriver` to choose between MySQL and MariaDB drivers
- MariaDB JDBC driver included in build artifacts

### Changed
- Updated database configuration comments to reflect MySQL/MariaDB support
- Improved connection string handling for multiple SQL drivers

### Removed
- Automatic uploads to CurseForge and Modrinth (can be re-enabled manually)

