### PR TITLE
Fix silently dropped logs when a referenced levels/users row isn't persisted yet

### DIFF
--- a/common/src/main/java/com/daqem/grieflogger/block/container/ContainerTransactionManager.java
+++ b/common/src/main/java/com/daqem/grieflogger/block/container/ContainerTransactionManager.java
@@ -31,6 +31,8 @@ public class ContainerTransactionManager implements IContainerTransactionManager
         List<SimpleItemStack> removedItems = getRemovedItems();
         List<SimpleItemStack> addedItems = getAddedItems();
 
+        // Ensure the actor's users row exists before logging the transaction. (GAP E)
+        Services.USER.ensure(serverPlayer.getUUID(), serverPlayer.getGameProfile().getName());
         Services.CONTAINER.insertMap(
                 serverPlayer.getUUID(),
                 blockEntity.getLevel() != null ? blockEntity.getLevel() : serverPlayer.level(),

--- a/common/src/main/java/com/daqem/grieflogger/block/container/ContainersTransactionManager.java
+++ b/common/src/main/java/com/daqem/grieflogger/block/container/ContainersTransactionManager.java
@@ -32,6 +32,8 @@ public class ContainersTransactionManager implements IContainerTransactionManage
     }
 
     public void finalize(ServerPlayer serverPlayer) {
+        // Ensure the actor's users row exists before logging any of these transactions. (GAP E)
+        Services.USER.ensure(serverPlayer.getUUID(), serverPlayer.getGameProfile().getName());
         for (BaseContainerBlockEntity blockEntity : blockEntities) {
             constructFinalItems(blockEntity);
 

--- a/common/src/main/java/com/daqem/grieflogger/database/Database.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/Database.java
@@ -5,6 +5,7 @@ import com.daqem.grieflogger.GriefLoggerExpectPlatform;
 import com.daqem.grieflogger.config.GriefLoggerConfig;
 import com.daqem.grieflogger.database.queue.IQueue;
 import com.daqem.grieflogger.database.queue.Queue;
+import com.daqem.grieflogger.database.queue.QueuedStatement;
 import com.supermartijn642.configlib.ConfigLib;
 import org.jetbrains.annotations.Nullable;
 
@@ -125,9 +126,10 @@ public class Database {
         }
     }
 
-    public void executeStatements(List<PreparedStatement> statements, boolean isBatch) {
+    public void executeStatements(List<QueuedStatement> statements, boolean isBatch) {
         try {
-            for (PreparedStatement statement : statements) {
+            for (QueuedStatement queued : statements) {
+                PreparedStatement statement = queued.statement();
                 if (statement == null) {
                     GriefLogger.LOGGER.error("Statement is null");
                     continue;
@@ -142,7 +144,16 @@ public class Database {
                     if (isBatch) {
                         statement.executeBatch(); // Execute as a batch
                     } else {
-                        statement.executeUpdate(); // Execute individually
+                        int affectedRows = statement.executeUpdate(); // Execute individually
+                        if (queued.shouldWarnDropped(affectedRows)) {
+                            // A tagged event insert that stored nothing: its level/user/material
+                            // reference was missing at flush time, so INSERT OR IGNORE discarded it.
+                            // Previously invisible (the affected-row count was ignored). (GAP E)
+                            GriefLogger.LOGGER.warn(
+                                    "Dropped a logged {} event: the insert affected 0 rows because a referenced "
+                                            + "level/user/material row was missing at flush time. The event was not stored.",
+                                    queued.eventLabel());
+                        }
                     }
                 }
             }

--- a/common/src/main/java/com/daqem/grieflogger/database/queue/IQueue.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/queue/IQueue.java
@@ -5,6 +5,15 @@ import java.sql.PreparedStatement;
 public interface IQueue {
 
     void add(PreparedStatement statement);
+
+    /**
+     * Enqueue an <em>event</em> insert (block/container/item) tagged for observability: if it affects
+     * 0 rows at flush time it was silently dropped and is warned about, using {@code eventLabel} as
+     * context. Dedup parent upserts use {@link #add(PreparedStatement)} (untagged) so their normal
+     * 0-row "already exists" result is not warned.
+     */
+    void add(PreparedStatement statement, String eventLabel);
+
     void execute();
     void hello();
 }

--- a/common/src/main/java/com/daqem/grieflogger/database/queue/Queue.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/queue/Queue.java
@@ -11,7 +11,7 @@ public class Queue implements IQueue {
 
     private final Database database;
     private final boolean isBatch;
-    private final List<PreparedStatement> statements = new ArrayList<>();
+    private final List<QueuedStatement> statements = new ArrayList<>();
 
     public Queue(Database database, boolean isBatch) {
         this.database = database;
@@ -20,7 +20,12 @@ public class Queue implements IQueue {
 
     @Override
     public void add(PreparedStatement statement) {
-        this.statements.add(statement);
+        this.statements.add(QueuedStatement.untagged(statement));
+    }
+
+    @Override
+    public void add(PreparedStatement statement, String eventLabel) {
+        this.statements.add(new QueuedStatement(statement, eventLabel));
     }
 
     @Override
@@ -28,7 +33,7 @@ public class Queue implements IQueue {
         if (this.statements.isEmpty()) {
             return;
         }
-        List<PreparedStatement> statements = new ArrayList<>(this.statements);
+        List<QueuedStatement> statements = new ArrayList<>(this.statements);
         this.statements.clear();
         this.database.executeStatements(statements, isBatch);
     }

--- a/common/src/main/java/com/daqem/grieflogger/database/queue/QueuedStatement.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/queue/QueuedStatement.java
@@ -1,0 +1,28 @@
+package com.daqem.grieflogger.database.queue;
+
+import java.sql.PreparedStatement;
+
+/**
+ * A queued {@link PreparedStatement} paired with an optional event label for observability.
+ *
+ * <p>When {@code eventLabel} is non-null the statement is an <em>event</em> insert
+ * (block/container/item) whose persistence matters: if it affects 0 rows at flush time it was
+ * silently dropped (a referenced level/user/material row was missing), which is a bug worth warning
+ * about. When {@code eventLabel} is null the statement is a dedup parent upsert
+ * (materials/levels/users/entities) where affecting 0 rows simply means "already exists" — normal,
+ * never warned. The label also gives the warning its context (which kind of event was lost).
+ *
+ * <p>Pure (no Minecraft types), so the warn decision is unit-testable without a runtime.
+ */
+public record QueuedStatement(PreparedStatement statement, String eventLabel) {
+
+    /** A statement with no observability tagging (dedup parent upserts, batch statements). */
+    public static QueuedStatement untagged(PreparedStatement statement) {
+        return new QueuedStatement(statement, null);
+    }
+
+    /** Whether a 0-affected-rows result for this statement is a silent drop that should warn. */
+    public boolean shouldWarnDropped(int affectedRows) {
+        return eventLabel != null && affectedRows == 0;
+    }
+}

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/BlockRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/BlockRepository.java
@@ -98,7 +98,7 @@ public class BlockRepository extends Repository {
             blockStatement.setInt(6, z);
             blockStatement.setString(7, material);
             blockStatement.setInt(8, blockAction);
-            database.queue.add(blockStatement);
+            database.queue.add(blockStatement, "block");
         } catch (SQLException exception) {
             GriefLogger.LOGGER.error("Failed to insert block into database", exception);
         }
@@ -129,7 +129,7 @@ public class BlockRepository extends Repository {
             blockStatement.setInt(6, z);
             blockStatement.setString(7, entity);
             blockStatement.setInt(8, blockAction);
-            database.queue.add(blockStatement);
+            database.queue.add(blockStatement, "entity");
         } catch (SQLException exception) {
             GriefLogger.LOGGER.error("Failed to insert block into database", exception);
         }

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/BlockRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/BlockRepository.java
@@ -72,43 +72,19 @@ public class BlockRepository extends Repository {
     }
 
     public void insertMaterial(long time, String userUuid, String levelName, int x, int y, int z, String material, int blockAction) {
-        String materialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            materialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String blockQuery = """
-                INSERT OR IGNORE INTO blocks(time, user, level, x, y, z, type, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?);
-                """;
-
-        if (isMysql()) {
-            blockQuery = """
-                    INSERT IGNORE INTO blocks(time, user, level, x, y, z, type, action)
-                    VALUES(?, (
-                        SELECT id FROM users WHERE uuid = ?
-                    ), (
-                        SELECT id FROM levels WHERE name = ?
-                    ), ?, ?, ?, (
-                        SELECT id FROM materials WHERE name = ?
-                    ), ?);
-                    """;
-        }
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? BlockSql.LEVEL_UPSERT_MYSQL : BlockSql.LEVEL_UPSERT_SQLITE;
+        String materialQuery = mysql ? BlockSql.MATERIAL_UPSERT_MYSQL : BlockSql.MATERIAL_UPSERT_SQLITE;
+        String blockQuery = mysql ? BlockSql.BLOCK_INSERT_MYSQL : BlockSql.BLOCK_INSERT_SQLITE;
 
         try {
+            // Ensure parent rows exist before the dependent insert so the FK sub-selects resolve;
+            // otherwise a not-yet-persisted level/material yields NULL -> NOT NULL violation ->
+            // the event is silently dropped by INSERT OR IGNORE. (GAP E)
+            PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+            levelStatement.setString(1, levelName);
+            database.queue.add(levelStatement);
+
             PreparedStatement materialStatement = database.prepareStatement(materialQuery);
             materialStatement.setString(1, material);
             database.queue.add(materialStatement);
@@ -129,49 +105,22 @@ public class BlockRepository extends Repository {
     }
 
     public void insertEntity(long time, String userUuid, String levelName, int x, int y, int z, String entity, int blockAction) {
-        String materialQuery = """
-                INSERT OR IGNORE INTO entities(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            materialQuery = """
-                    INSERT IGNORE INTO entities(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String blockQuery = """
-                INSERT OR IGNORE INTO blocks(time, user, level, x, y, z, type, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM entities WHERE name = ?
-                ), ?);
-                """;
-
-        if (isMysql()) {
-            blockQuery = """
-                    INSERT IGNORE INTO blocks(time, user, level, x, y, z, type, action)
-                    VALUES(?, (
-                        SELECT id FROM users WHERE uuid = ?
-                    ), (
-                        SELECT id FROM levels WHERE name = ?
-                    ), ?, ?, ?, (
-                        SELECT id FROM entities WHERE name = ?
-                    ), ?);
-                    """;
-        }
-
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? BlockSql.LEVEL_UPSERT_MYSQL : BlockSql.LEVEL_UPSERT_SQLITE;
+        String entityQuery = mysql ? BlockSql.ENTITY_UPSERT_MYSQL : BlockSql.ENTITY_UPSERT_SQLITE;
+        String blockQuery = mysql ? BlockSql.ENTITY_BLOCK_INSERT_MYSQL : BlockSql.ENTITY_BLOCK_INSERT_SQLITE;
 
         try {
-            PreparedStatement materialStatement = database.prepareStatement(materialQuery);
-            PreparedStatement blockStatement = database.prepareStatement(blockQuery);
-            materialStatement.setString(1, entity);
-            database.queue.add(materialStatement);
+            // Ensure parent rows exist before the dependent insert (see insertMaterial / GAP E).
+            PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+            levelStatement.setString(1, levelName);
+            database.queue.add(levelStatement);
 
+            PreparedStatement entityStatement = database.prepareStatement(entityQuery);
+            entityStatement.setString(1, entity);
+            database.queue.add(entityStatement);
+
+            PreparedStatement blockStatement = database.prepareStatement(blockQuery);
             blockStatement.setLong(1, time);
             blockStatement.setString(2, userUuid);
             blockStatement.setString(3, levelName);
@@ -188,17 +137,7 @@ public class BlockRepository extends Repository {
 
     public List<IHistory> getBlockHistory(String levelName, int x, int y, int z) {
         List<IHistory> blockHistory = new ArrayList<>();
-        String query = """
-                SELECT blocks.time, users.name, users.uuid, blocks.x, blocks.y, blocks.z, materials.name, blocks.action
-                FROM blocks
-                INNER JOIN users ON blocks.user = users.id
-                INNER JOIN levels ON blocks.level = (
-                    SELECT id FROM levels WHERE name = ?
-                )
-                INNER JOIN materials ON blocks.type = materials.id
-                WHERE blocks.level = levels.id AND blocks.x = ? AND blocks.y = ? AND blocks.z = ? AND (blocks.action = 0 OR blocks.action = 1)
-                ORDER BY blocks.time DESC
-                """;
+        String query = isMysql() ? BlockSql.BLOCK_HISTORY_BY_POSITION_MYSQL : BlockSql.BLOCK_HISTORY_BY_POSITION_SQLITE;
 
         try (PreparedStatement preparedStatement = database.prepareStatement(query)) {
             preparedStatement.setString(1, levelName);
@@ -226,17 +165,7 @@ public class BlockRepository extends Repository {
 
     public List<IHistory> getInteractionHistory(String levelName, int x, int y, int z) {
         List<IHistory> blockHistory = new ArrayList<>();
-        String query = """
-                SELECT blocks.time, users.name, users.uuid, blocks.x, blocks.y, blocks.z, materials.name, blocks.action
-                FROM blocks
-                INNER JOIN users ON blocks.user = users.id
-                INNER JOIN levels ON blocks.level = (
-                    SELECT id FROM levels WHERE name = ?
-                )
-                INNER JOIN materials ON blocks.type = materials.id
-                WHERE blocks.level = levels.id AND blocks.x = ? AND blocks.y = ? AND blocks.z = ? AND blocks.action = 2
-                ORDER BY blocks.time DESC
-                """;
+        String query = isMysql() ? BlockSql.INTERACTION_HISTORY_BY_POSITION_MYSQL : BlockSql.INTERACTION_HISTORY_BY_POSITION_SQLITE;
 
         try (PreparedStatement preparedStatement = database.prepareStatement(query)) {
             preparedStatement.setString(1, levelName);

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/BlockSql.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/BlockSql.java
@@ -1,0 +1,75 @@
+package com.daqem.grieflogger.database.repository;
+
+/**
+ * Centralized SQL for block/entity persistence and position lookups.
+ *
+ * <p>Kept free of any Minecraft/mod types so the exact statements the repositories emit can be
+ * exercised directly against a database in tests. Two dialect variants are provided where they
+ * differ: SQLite (default backend) uses {@code INSERT OR IGNORE}; MySQL uses {@code INSERT IGNORE}.
+ *
+ * <p>Reliability (GAP E): a logged event is dropped when a {@code NOT NULL} foreign key
+ * ({@code level}/{@code user}/{@code type}) resolves to {@code NULL} because its parent row did not
+ * exist yet. Callers MUST upsert the parent rows (level, user, material/entity) before the event
+ * insert so the sub-selects resolve. Position lookups use the standard
+ * {@code JOIN levels ON blocks.level = levels.id WHERE levels.name = ?} form so a missing/late
+ * level row cannot zero out results for events that are stored.
+ */
+public final class BlockSql {
+
+    private BlockSql() {
+    }
+
+    // --- parent upserts (idempotent; run before the event insert) ---
+
+    public static final String MATERIAL_UPSERT_SQLITE = "INSERT OR IGNORE INTO materials(name) VALUES(?)";
+    public static final String MATERIAL_UPSERT_MYSQL = "INSERT IGNORE INTO materials(name) VALUES(?)";
+
+    public static final String ENTITY_UPSERT_SQLITE = "INSERT OR IGNORE INTO entities(name) VALUES(?)";
+    public static final String ENTITY_UPSERT_MYSQL = "INSERT IGNORE INTO entities(name) VALUES(?)";
+
+    public static final String LEVEL_UPSERT_SQLITE = "INSERT OR IGNORE INTO levels(name) VALUES(?)";
+    public static final String LEVEL_UPSERT_MYSQL = "INSERT IGNORE INTO levels(name) VALUES(?)";
+
+    // users.name is NOT NULL, so the upsert carries the player name; keyed on the unique uuid.
+    // Params: 1=name, 2=uuid, 3=name (conflict update)
+    public static final String USER_UPSERT_SQLITE =
+            "INSERT INTO users(name, uuid) VALUES(?, ?) ON CONFLICT(uuid) DO UPDATE SET name = ?";
+    public static final String USER_UPSERT_MYSQL =
+            "INSERT INTO users(name, uuid) VALUES(?, ?) ON DUPLICATE KEY UPDATE name = ?";
+
+    // --- event inserts (resolve FKs via sub-select; parents must already be upserted) ---
+    // Params: 1=time, 2=uuid, 3=levelName, 4=x, 5=y, 6=z, 7=material|entity, 8=action
+
+    public static final String BLOCK_INSERT_SQLITE = """
+            INSERT OR IGNORE INTO blocks(time, user, level, x, y, z, type, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM materials WHERE name = ?), ?)""";
+    public static final String BLOCK_INSERT_MYSQL = """
+            INSERT IGNORE INTO blocks(time, user, level, x, y, z, type, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM materials WHERE name = ?), ?)""";
+
+    public static final String ENTITY_BLOCK_INSERT_SQLITE = """
+            INSERT OR IGNORE INTO blocks(time, user, level, x, y, z, type, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM entities WHERE name = ?), ?)""";
+    public static final String ENTITY_BLOCK_INSERT_MYSQL = """
+            INSERT IGNORE INTO blocks(time, user, level, x, y, z, type, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM entities WHERE name = ?), ?)""";
+
+    // --- normalized position lookups (dialect-neutral) ---
+    // Params: 1=levelName, 2=x, 3=y, 4=z
+
+    private static final String HISTORY_SELECT = """
+            SELECT blocks.time, users.name, users.uuid, blocks.x, blocks.y, blocks.z, materials.name, blocks.action
+            FROM blocks
+            INNER JOIN users ON blocks.user = users.id
+            INNER JOIN levels ON blocks.level = levels.id
+            INNER JOIN materials ON blocks.type = materials.id
+            WHERE levels.name = ? AND blocks.x = ? AND blocks.y = ? AND blocks.z = ?""";
+
+    public static final String BLOCK_HISTORY_BY_POSITION_SQLITE =
+            HISTORY_SELECT + " AND (blocks.action = 0 OR blocks.action = 1)\nORDER BY blocks.time DESC";
+    public static final String BLOCK_HISTORY_BY_POSITION_MYSQL = BLOCK_HISTORY_BY_POSITION_SQLITE;
+
+    public static final String INTERACTION_HISTORY_BY_POSITION_SQLITE =
+            HISTORY_SELECT + " AND blocks.action = 2\nORDER BY blocks.time DESC";
+    public static final String INTERACTION_HISTORY_BY_POSITION_MYSQL = INTERACTION_HISTORY_BY_POSITION_SQLITE;
+}

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/BlockSql.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/BlockSql.java
@@ -30,12 +30,13 @@ public final class BlockSql {
     public static final String LEVEL_UPSERT_SQLITE = "INSERT OR IGNORE INTO levels(name) VALUES(?)";
     public static final String LEVEL_UPSERT_MYSQL = "INSERT IGNORE INTO levels(name) VALUES(?)";
 
-    // users.name is NOT NULL, so the upsert carries the player name; keyed on the unique uuid.
-    // Params: 1=name, 2=uuid, 3=name (conflict update)
-    public static final String USER_UPSERT_SQLITE =
-            "INSERT INTO users(name, uuid) VALUES(?, ?) ON CONFLICT(uuid) DO UPDATE SET name = ?";
-    public static final String USER_UPSERT_MYSQL =
-            "INSERT INTO users(name, uuid) VALUES(?, ?) ON DUPLICATE KEY UPDATE name = ?";
+    // Ensure the acting player's users row exists before an event insert resolves its user FK.
+    // Idempotent ensure-exists (mirrors the level/material upserts) — keyed on the unique uuid, so
+    // it neither rewrites the row nor touches username history on every event; name refreshes happen
+    // at join (UserRepository.insertOrUpdateName). users.name is NOT NULL, so carry the name.
+    // Params: 1=name, 2=uuid
+    public static final String USER_ENSURE_SQLITE = "INSERT OR IGNORE INTO users(name, uuid) VALUES(?, ?)";
+    public static final String USER_ENSURE_MYSQL = "INSERT IGNORE INTO users(name, uuid) VALUES(?, ?)";
 
     // --- event inserts (resolve FKs via sub-select; parents must already be upserted) ---
     // Params: 1=time, 2=uuid, 3=levelName, 4=x, 5=y, 6=z, 7=material|entity, 8=action

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerRepository.java
@@ -89,45 +89,36 @@ public class ContainerRepository extends Repository {
             return;
         }
 
-        String insertMaterialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            insertMaterialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String insertItemQuery = """
-                INSERT INTO containers(time, user, level, x, y, z, type, data, amount, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?, ?, ?);
-                """;
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? ContainerSql.LEVEL_UPSERT_MYSQL : ContainerSql.LEVEL_UPSERT_SQLITE;
+        String materialQuery = mysql ? ContainerSql.MATERIAL_UPSERT_MYSQL : ContainerSql.MATERIAL_UPSERT_SQLITE;
+        String insertItemQuery = mysql ? ContainerSql.CONTAINER_INSERT_MYSQL : ContainerSql.CONTAINER_INSERT_SQLITE;
 
         ResourceLocation itemLocation = item.getItem().arch$registryName();
         if (itemLocation != null) {
             try {
-                PreparedStatement itemStatement = database.prepareStatement(insertItemQuery);
-                PreparedStatement materialStatement = database.prepareStatement(insertMaterialQuery);
+                String materialName = itemLocation.toString().replace("minecraft:", "");
+                String levelName = level.dimension().location().toString();
 
-                materialStatement.setString(1, itemLocation.toString().replace("minecraft:", ""));
+                // Ensure parent rows exist before the dependent insert so the FK sub-selects
+                // resolve; otherwise a not-yet-persisted level/material yields NULL -> NOT NULL
+                // violation -> the plain INSERT throws and aborts the whole flush batch. (GAP E)
+                PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+                levelStatement.setString(1, levelName);
+                database.queue.add(levelStatement);
+
+                PreparedStatement materialStatement = database.prepareStatement(materialQuery);
+                materialStatement.setString(1, materialName);
                 database.queue.add(materialStatement);
 
+                PreparedStatement itemStatement = database.prepareStatement(insertItemQuery);
                 itemStatement.setLong(1, time);
                 itemStatement.setString(2, userUuid);
-                itemStatement.setString(3, level.dimension().location().toString());
+                itemStatement.setString(3, levelName);
                 itemStatement.setInt(4, x);
                 itemStatement.setInt(5, y);
                 itemStatement.setInt(6, z);
-                itemStatement.setString(7, itemLocation.toString().replace("minecraft:", ""));
+                itemStatement.setString(7, materialName);
                 itemStatement.setBytes(8, item.getTagBytes(level));
                 itemStatement.setInt(9, item.getCount());
                 itemStatement.setInt(10, itemAction);
@@ -139,30 +130,19 @@ public class ContainerRepository extends Repository {
     }
 
     public void insertList(long time, String userUuid, Level level, int x, int y, int z, List<SimpleItemStack> items, int itemAction) {
-        String insertMaterialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            insertMaterialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String insertItemQuery = """
-                INSERT INTO containers(time, user, level, x, y, z, type, data, amount, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?, ?, ?);
-                """;
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? ContainerSql.LEVEL_UPSERT_MYSQL : ContainerSql.LEVEL_UPSERT_SQLITE;
+        String insertMaterialQuery = mysql ? ContainerSql.MATERIAL_UPSERT_MYSQL : ContainerSql.MATERIAL_UPSERT_SQLITE;
+        String insertItemQuery = mysql ? ContainerSql.CONTAINER_INSERT_MYSQL : ContainerSql.CONTAINER_INSERT_SQLITE;
 
         try {
+            String levelName = level.dimension().location().toString();
+
+            // Upsert the (single) level parent in the same batch, ahead of the inserts. (GAP E)
+            PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+            levelStatement.setString(1, levelName);
+            levelStatement.addBatch();
+
             PreparedStatement itemStatement = database.prepareStatement(insertItemQuery);
             PreparedStatement materialStatement = database.prepareStatement(insertMaterialQuery);
 
@@ -172,22 +152,24 @@ public class ContainerRepository extends Repository {
                 }
                 ResourceLocation itemLocation = item.getItem().arch$registryName();
                 if (itemLocation != null) {
-                    materialStatement.setString(1, itemLocation.toString().replace("minecraft:", ""));
+                    String materialName = itemLocation.toString().replace("minecraft:", "");
+                    materialStatement.setString(1, materialName);
                     materialStatement.addBatch();
 
                     itemStatement.setLong(1, time);
                     itemStatement.setString(2, userUuid);
-                    itemStatement.setString(3, level.dimension().location().toString());
+                    itemStatement.setString(3, levelName);
                     itemStatement.setInt(4, x);
                     itemStatement.setInt(5, y);
                     itemStatement.setInt(6, z);
-                    itemStatement.setString(7, itemLocation.toString().replace("minecraft:", ""));
+                    itemStatement.setString(7, materialName);
                     itemStatement.setBytes(8, item.getTagBytes(level));
                     itemStatement.setInt(9, item.getCount());
                     itemStatement.setInt(10, itemAction);
                     itemStatement.addBatch();
                 }
             }
+            database.batchQueue.add(levelStatement);
             database.batchQueue.add(materialStatement);
             database.batchQueue.add(itemStatement);
         } catch (SQLException e) {
@@ -196,30 +178,19 @@ public class ContainerRepository extends Repository {
     }
 
     public void insertMap(long time, String userUuid, Level level, int x, int y, int z, Map<ItemAction, List<SimpleItemStack>> itemsMap) {
-        String insertMaterialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            insertMaterialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String insertItemQuery = """
-                INSERT INTO containers(time, user, level, x, y, z, type, data, amount, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?, ?, ?);
-                """;
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? ContainerSql.LEVEL_UPSERT_MYSQL : ContainerSql.LEVEL_UPSERT_SQLITE;
+        String insertMaterialQuery = mysql ? ContainerSql.MATERIAL_UPSERT_MYSQL : ContainerSql.MATERIAL_UPSERT_SQLITE;
+        String insertItemQuery = mysql ? ContainerSql.CONTAINER_INSERT_MYSQL : ContainerSql.CONTAINER_INSERT_SQLITE;
 
         try {
+            String levelName = level.dimension().location().toString();
+
+            // Upsert the (single) level parent in the same batch, ahead of the inserts. (GAP E)
+            PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+            levelStatement.setString(1, levelName);
+            levelStatement.addBatch();
+
             PreparedStatement itemStatement = database.prepareStatement(insertItemQuery);
             PreparedStatement materialStatement = database.prepareStatement(insertMaterialQuery);
 
@@ -230,16 +201,17 @@ public class ContainerRepository extends Repository {
                     }
                     ResourceLocation itemLocation = item.getItem().arch$registryName();
                     if (itemLocation != null) {
-                        materialStatement.setString(1, itemLocation.toString().replace("minecraft:", ""));
+                        String materialName = itemLocation.toString().replace("minecraft:", "");
+                        materialStatement.setString(1, materialName);
                         materialStatement.addBatch();
 
                         itemStatement.setLong(1, time);
                         itemStatement.setString(2, userUuid);
-                        itemStatement.setString(3, level.dimension().location().toString());
+                        itemStatement.setString(3, levelName);
                         itemStatement.setInt(4, x);
                         itemStatement.setInt(5, y);
                         itemStatement.setInt(6, z);
-                        itemStatement.setString(7, itemLocation.toString().replace("minecraft:", ""));
+                        itemStatement.setString(7, materialName);
                         itemStatement.setBytes(8, item.getTagBytes(level));
                         itemStatement.setInt(9, item.getCount());
                         itemStatement.setInt(10, entry.getKey().getId());
@@ -247,6 +219,7 @@ public class ContainerRepository extends Repository {
                     }
                 }
             }
+            database.batchQueue.add(levelStatement);
             database.batchQueue.add(materialStatement);
             database.batchQueue.add(itemStatement);
         } catch (SQLException e) {
@@ -256,17 +229,7 @@ public class ContainerRepository extends Repository {
 
     public List<IHistory> getHistory(Level level, int x, int y, int z) {
         List<IHistory> containerHistory = new ArrayList<>();
-        String query = """
-                SELECT containers.time, users.name, users.uuid, containers.x, containers.y, containers.z, materials.name, containers.data, containers.amount, containers.action
-                FROM containers
-                INNER JOIN users ON containers.user = users.id
-                INNER JOIN levels ON containers.level = (
-                    SELECT id FROM levels WHERE name = ?
-                )
-                INNER JOIN materials ON containers.type = materials.id
-                WHERE containers.level = levels.id AND containers.x = ? AND containers.y = ? AND containers.z = ? AND (containers.action = 0 OR containers.action = 1)
-                ORDER BY containers.time DESC
-                """;
+        String query = isMysql() ? ContainerSql.CONTAINER_HISTORY_BY_POSITION_MYSQL : ContainerSql.CONTAINER_HISTORY_BY_POSITION_SQLITE;
 
         try (PreparedStatement preparedStatement = database.prepareStatement(query)) {
             preparedStatement.setString(1, level.dimension().location().toString());
@@ -300,17 +263,7 @@ public class ContainerRepository extends Repository {
 
     public List<IHistory> getHistory(Level level, int x, int y, int z, int x2, int y2, int z2) {
         List<IHistory> containerHistory = new ArrayList<>();
-        String query = """
-                SELECT containers.time, users.name, users.uuid, containers.x, containers.y, containers.z, materials.name, containers.data, containers.amount, containers.action
-                FROM containers
-                INNER JOIN users ON containers.user = users.id
-                INNER JOIN levels ON containers.level = (
-                    SELECT id FROM levels WHERE name = ?
-                )
-                INNER JOIN materials ON containers.type = materials.id
-                WHERE containers.level = levels.id AND containers.x BETWEEN ? AND ? AND containers.y BETWEEN ? AND ? AND containers.z BETWEEN ? AND ? AND (containers.action = 0 OR containers.action = 1)
-                ORDER BY containers.time DESC
-                """;
+        String query = isMysql() ? ContainerSql.CONTAINER_HISTORY_BY_RANGE_MYSQL : ContainerSql.CONTAINER_HISTORY_BY_RANGE_SQLITE;
 
         try (PreparedStatement preparedStatement = database.prepareStatement(query)) {
             preparedStatement.setString(1, level.dimension().location().toString());

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerRepository.java
@@ -122,7 +122,7 @@ public class ContainerRepository extends Repository {
                 itemStatement.setBytes(8, item.getTagBytes(level));
                 itemStatement.setInt(9, item.getCount());
                 itemStatement.setInt(10, itemAction);
-                database.queue.add(itemStatement);
+                database.queue.add(itemStatement, "container");
             } catch (SQLException e) {
                 GriefLogger.LOGGER.error("Failed to insert item", e);
             }

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerSql.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ContainerSql.java
@@ -1,0 +1,60 @@
+package com.daqem.grieflogger.database.repository;
+
+/**
+ * Centralized SQL for container (chest/barrel/etc.) transaction persistence and position lookups.
+ *
+ * <p>Kept free of any Minecraft/mod types so the exact statements the repository emits can be
+ * exercised directly against a database in tests. Two dialect variants are provided where they
+ * differ: SQLite (default backend) uses {@code INSERT OR IGNORE}; MySQL uses {@code INSERT IGNORE}.
+ *
+ * <p>Reliability (GAP E): the container insert is a plain {@code INSERT} that resolves its
+ * {@code NOT NULL} foreign keys ({@code level}/{@code user}/{@code type}) via scalar sub-selects.
+ * A missing parent row makes a sub-select resolve to {@code NULL}, which violates the column and
+ * throws — aborting the whole flush batch's commit. Callers MUST upsert the parent rows (level,
+ * user, material) before the transaction insert so the sub-selects resolve. Position lookups use
+ * the standard {@code JOIN levels ON containers.level = levels.id WHERE levels.name = ?} form
+ * rather than a sub-select join.
+ */
+public final class ContainerSql {
+
+    private ContainerSql() {
+    }
+
+    // --- parent upserts (idempotent; run before the transaction insert) ---
+
+    public static final String MATERIAL_UPSERT_SQLITE = "INSERT OR IGNORE INTO materials(name) VALUES(?)";
+    public static final String MATERIAL_UPSERT_MYSQL = "INSERT IGNORE INTO materials(name) VALUES(?)";
+
+    public static final String LEVEL_UPSERT_SQLITE = "INSERT OR IGNORE INTO levels(name) VALUES(?)";
+    public static final String LEVEL_UPSERT_MYSQL = "INSERT IGNORE INTO levels(name) VALUES(?)";
+
+    // --- transaction insert (resolves FKs via sub-select; parents must already be upserted) ---
+    // Params: 1=time, 2=uuid, 3=levelName, 4=x, 5=y, 6=z, 7=material, 8=data, 9=amount, 10=action
+
+    public static final String CONTAINER_INSERT_SQLITE = """
+            INSERT INTO containers(time, user, level, x, y, z, type, data, amount, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM materials WHERE name = ?), ?, ?, ?)""";
+    public static final String CONTAINER_INSERT_MYSQL = CONTAINER_INSERT_SQLITE;
+
+    // --- normalized position lookups (dialect-neutral) ---
+    // Single position params: 1=levelName, 2=x, 3=y, 4=z
+    // Range params:           1=levelName, 2=x1, 3=x2, 4=y1, 5=y2, 6=z1, 7=z2
+
+    private static final String HISTORY_SELECT = """
+            SELECT containers.time, users.name, users.uuid, containers.x, containers.y, containers.z, materials.name, containers.data, containers.amount, containers.action
+            FROM containers
+            INNER JOIN users ON containers.user = users.id
+            INNER JOIN levels ON containers.level = levels.id
+            INNER JOIN materials ON containers.type = materials.id
+            WHERE levels.name = ?""";
+
+    public static final String CONTAINER_HISTORY_BY_POSITION_SQLITE = HISTORY_SELECT
+            + " AND containers.x = ? AND containers.y = ? AND containers.z = ?"
+            + " AND (containers.action = 0 OR containers.action = 1)\nORDER BY containers.time DESC";
+    public static final String CONTAINER_HISTORY_BY_POSITION_MYSQL = CONTAINER_HISTORY_BY_POSITION_SQLITE;
+
+    public static final String CONTAINER_HISTORY_BY_RANGE_SQLITE = HISTORY_SELECT
+            + " AND containers.x BETWEEN ? AND ? AND containers.y BETWEEN ? AND ? AND containers.z BETWEEN ? AND ?"
+            + " AND (containers.action = 0 OR containers.action = 1)\nORDER BY containers.time DESC";
+    public static final String CONTAINER_HISTORY_BY_RANGE_MYSQL = CONTAINER_HISTORY_BY_RANGE_SQLITE;
+}

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ItemRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ItemRepository.java
@@ -120,7 +120,7 @@ public class ItemRepository extends Repository {
                 preparedStatement.setBytes(8, item.getTagBytes(level));
                 preparedStatement.setInt(9, item.getCount());
                 preparedStatement.setInt(10, action);
-                database.queue.add(preparedStatement);
+                database.queue.add(preparedStatement, "item");
             } catch (SQLException exception) {
                 GriefLogger.LOGGER.error("Failed to insert item into database", exception);
             }

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ItemRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ItemRepository.java
@@ -87,45 +87,36 @@ public class ItemRepository extends Repository {
         if (item.isEmpty()) {
             return;
         }
-        String materialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            materialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String itemQuery = """
-                INSERT INTO items(time, user, level, x, y, z, type, data, amount, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?, ?, ?);
-                """;
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? ItemSql.LEVEL_UPSERT_MYSQL : ItemSql.LEVEL_UPSERT_SQLITE;
+        String materialQuery = mysql ? ItemSql.MATERIAL_UPSERT_MYSQL : ItemSql.MATERIAL_UPSERT_SQLITE;
+        String itemQuery = mysql ? ItemSql.ITEM_INSERT_MYSQL : ItemSql.ITEM_INSERT_SQLITE;
 
         ResourceLocation itemLocation = item.getItem().arch$registryName();
         if (itemLocation != null) {
             try {
-                PreparedStatement preparedStatement = database.prepareStatement(itemQuery);
-                PreparedStatement materialStatement = database.prepareStatement(materialQuery);
+                String materialName = itemLocation.toString().replace("minecraft:", "");
+                String levelName = level.dimension().location().toString();
 
-                materialStatement.setString(1, itemLocation.toString().replace("minecraft:", ""));
+                // Ensure parent rows exist before the dependent insert so the FK sub-selects
+                // resolve; otherwise a not-yet-persisted level/material yields NULL -> NOT NULL
+                // violation -> the plain INSERT throws and aborts the whole flush batch. (GAP E)
+                PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+                levelStatement.setString(1, levelName);
+                database.queue.add(levelStatement);
+
+                PreparedStatement materialStatement = database.prepareStatement(materialQuery);
+                materialStatement.setString(1, materialName);
                 database.queue.add(materialStatement);
 
+                PreparedStatement preparedStatement = database.prepareStatement(itemQuery);
                 preparedStatement.setLong(1, time);
                 preparedStatement.setString(2, userUuid);
-                preparedStatement.setString(3, level.dimension().location().toString());
+                preparedStatement.setString(3, levelName);
                 preparedStatement.setInt(4, x);
                 preparedStatement.setInt(5, y);
                 preparedStatement.setInt(6, z);
-                preparedStatement.setString(7, itemLocation.toString().replace("minecraft:", ""));
+                preparedStatement.setString(7, materialName);
                 preparedStatement.setBytes(8, item.getTagBytes(level));
                 preparedStatement.setInt(9, item.getCount());
                 preparedStatement.setInt(10, action);
@@ -137,30 +128,19 @@ public class ItemRepository extends Repository {
     }
 
     public void insertMap(long time, String userUuid, Level level, int x, int y, int z, Map<ItemAction, List<SimpleItemStack>> itemsMap) {
-        String insertMaterialQuery = """
-                INSERT OR IGNORE INTO materials(name)
-                VALUES(?);
-                """;
-
-        if (isMysql()) {
-            insertMaterialQuery = """
-                    INSERT IGNORE INTO materials(name)
-                    VALUES(?);
-                    """;
-        }
-
-        String insertItemQuery = """
-                INSERT INTO items(time, user, level, x, y, z, type, data, amount, action)
-                VALUES(?, (
-                    SELECT id FROM users WHERE uuid = ?
-                ), (
-                    SELECT id FROM levels WHERE name = ?
-                ), ?, ?, ?, (
-                    SELECT id FROM materials WHERE name = ?
-                ), ?, ?, ?);
-                """;
+        boolean mysql = isMysql();
+        String levelQuery = mysql ? ItemSql.LEVEL_UPSERT_MYSQL : ItemSql.LEVEL_UPSERT_SQLITE;
+        String insertMaterialQuery = mysql ? ItemSql.MATERIAL_UPSERT_MYSQL : ItemSql.MATERIAL_UPSERT_SQLITE;
+        String insertItemQuery = mysql ? ItemSql.ITEM_INSERT_MYSQL : ItemSql.ITEM_INSERT_SQLITE;
 
         try {
+            String levelName = level.dimension().location().toString();
+
+            // Upsert the (single) level parent in the same batch, ahead of the inserts. (GAP E)
+            PreparedStatement levelStatement = database.prepareStatement(levelQuery);
+            levelStatement.setString(1, levelName);
+            levelStatement.addBatch();
+
             PreparedStatement itemStatement = database.prepareStatement(insertItemQuery);
             PreparedStatement materialStatement = database.prepareStatement(insertMaterialQuery);
 
@@ -171,16 +151,17 @@ public class ItemRepository extends Repository {
                     }
                     ResourceLocation itemLocation = item.getItem().arch$registryName();
                     if (itemLocation != null) {
-                        materialStatement.setString(1, itemLocation.toString().replace("minecraft:", ""));
+                        String materialName = itemLocation.toString().replace("minecraft:", "");
+                        materialStatement.setString(1, materialName);
                         materialStatement.addBatch();
 
                         itemStatement.setLong(1, time);
                         itemStatement.setString(2, userUuid);
-                        itemStatement.setString(3, level.dimension().location().toString());
+                        itemStatement.setString(3, levelName);
                         itemStatement.setInt(4, x);
                         itemStatement.setInt(5, y);
                         itemStatement.setInt(6, z);
-                        itemStatement.setString(7, itemLocation.toString().replace("minecraft:", ""));
+                        itemStatement.setString(7, materialName);
                         itemStatement.setBytes(8, item.getTagBytes(level));
                         itemStatement.setInt(9, item.getCount());
                         itemStatement.setInt(10, entry.getKey().getId());
@@ -188,6 +169,7 @@ public class ItemRepository extends Repository {
                     }
                 }
             }
+            database.batchQueue.add(levelStatement);
             database.batchQueue.add(materialStatement);
             database.batchQueue.add(itemStatement);
         } catch (SQLException e) {

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/ItemSql.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/ItemSql.java
@@ -1,0 +1,38 @@
+package com.daqem.grieflogger.database.repository;
+
+/**
+ * Centralized SQL for item (drop/pickup/inventory) event persistence.
+ *
+ * <p>Kept free of any Minecraft/mod types so the exact statements the repository emits can be
+ * exercised directly against a database in tests. Two dialect variants are provided where they
+ * differ: SQLite (default backend) uses {@code INSERT OR IGNORE}; MySQL uses {@code INSERT IGNORE}.
+ *
+ * <p>Reliability (GAP E): the item insert is a plain {@code INSERT} that resolves its
+ * {@code NOT NULL} foreign keys ({@code level}/{@code user}/{@code type}) via scalar sub-selects.
+ * A missing parent row makes a sub-select resolve to {@code NULL}, which violates the column and
+ * throws — aborting the whole flush batch's commit. Callers MUST upsert the parent rows (level,
+ * user, material) before the item insert so the sub-selects resolve. The item inspect query
+ * ({@code ItemRepository.getFilteredItemHistory}) already uses a normalized
+ * {@code JOIN levels ON items.level = levels.id WHERE levels.name = ?}, so no read change is needed.
+ */
+public final class ItemSql {
+
+    private ItemSql() {
+    }
+
+    // --- parent upserts (idempotent; run before the item insert) ---
+
+    public static final String MATERIAL_UPSERT_SQLITE = "INSERT OR IGNORE INTO materials(name) VALUES(?)";
+    public static final String MATERIAL_UPSERT_MYSQL = "INSERT IGNORE INTO materials(name) VALUES(?)";
+
+    public static final String LEVEL_UPSERT_SQLITE = "INSERT OR IGNORE INTO levels(name) VALUES(?)";
+    public static final String LEVEL_UPSERT_MYSQL = "INSERT IGNORE INTO levels(name) VALUES(?)";
+
+    // --- item insert (resolves FKs via sub-select; parents must already be upserted) ---
+    // Params: 1=time, 2=uuid, 3=levelName, 4=x, 5=y, 6=z, 7=material, 8=data, 9=amount, 10=action
+
+    public static final String ITEM_INSERT_SQLITE = """
+            INSERT INTO items(time, user, level, x, y, z, type, data, amount, action)
+            VALUES(?, (SELECT id FROM users WHERE uuid = ?), (SELECT id FROM levels WHERE name = ?), ?, ?, ?, (SELECT id FROM materials WHERE name = ?), ?, ?, ?)""";
+    public static final String ITEM_INSERT_MYSQL = ITEM_INSERT_SQLITE;
+}

--- a/common/src/main/java/com/daqem/grieflogger/database/repository/UserRepository.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/repository/UserRepository.java
@@ -64,6 +64,18 @@ public class UserRepository extends Repository {
         }
     }
 
+    public void ensureExists(String name, String uuid) {
+        String query = isMysql() ? BlockSql.USER_ENSURE_MYSQL : BlockSql.USER_ENSURE_SQLITE;
+        try {
+            PreparedStatement preparedStatement = database.prepareStatement(query);
+            preparedStatement.setString(1, name);
+            preparedStatement.setString(2, uuid);
+            database.queue.add(preparedStatement);
+        } catch (SQLException exception) {
+            GriefLogger.LOGGER.error("Failed to ensure user exists in database", exception);
+        }
+    }
+
     public void insertNonPlayer(String name) {
         String query = """
                 INSERT INTO users(name)

--- a/common/src/main/java/com/daqem/grieflogger/database/service/UserService.java
+++ b/common/src/main/java/com/daqem/grieflogger/database/service/UserService.java
@@ -26,6 +26,15 @@ public class UserService {
         usernameService.insert(uuid, name);
     }
 
+    /**
+     * Ensure the player's {@code users} row exists (idempotent, name-carrying) so an event insert's
+     * {@code user} foreign key resolves. Lighter than {@link #insertOrUpdateName}: no name rewrite and
+     * no username-history row per event — name refreshes still happen at join.
+     */
+    public void ensure(UUID uuid, String name) {
+        userRepository.ensureExists(name, uuid.toString());
+    }
+
     public Map<Integer, String> getAllUsernames() {
         return userRepository.getAllUsernames();
     }

--- a/common/src/main/java/com/daqem/grieflogger/event/EntityEvents.java
+++ b/common/src/main/java/com/daqem/grieflogger/event/EntityEvents.java
@@ -14,6 +14,8 @@ public class EntityEvents {
             if (source.getEntity() instanceof ServerPlayer serverPlayer) {
                 ResourceLocation entityLocation = entity.getType().arch$registryName();
                 if (entityLocation != null) {
+                    // Ensure the killer's users row exists before logging the kill. (GAP E)
+                    Services.USER.ensure(serverPlayer.getUUID(), serverPlayer.getGameProfile().getName());
                     Services.BLOCK.insertEntity(
                             serverPlayer.getUUID(),
                             entity.level().dimension().location().toString(),

--- a/common/src/main/java/com/daqem/grieflogger/event/block/LogBlockEvent.java
+++ b/common/src/main/java/com/daqem/grieflogger/event/block/LogBlockEvent.java
@@ -6,6 +6,7 @@ import com.daqem.grieflogger.model.action.BlockAction;
 import com.daqem.grieflogger.player.GriefLoggerServerPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -14,8 +15,12 @@ public class LogBlockEvent extends AbstractEvent {
     public static void logBlock(GriefLoggerServerPlayer player, Level level, BlockState state, BlockPos pos, BlockAction blockAction) {
         ResourceLocation materialLocation = state.getBlock().arch$registryName();
         if (materialLocation != null) {
+            ServerPlayer serverPlayer = player.grieflogger$asServerPlayer();
+            // Ensure the actor's users row exists before logging their action, so the event's
+            // user FK never resolves NULL (which would drop/abort the insert). (GAP E)
+            Services.USER.ensure(serverPlayer.getUUID(), serverPlayer.getGameProfile().getName());
             Services.BLOCK.insertMaterial(
-                    player.grieflogger$asServerPlayer().getUUID(),
+                    serverPlayer.getUUID(),
                     level.dimension().location().toString(),
                     pos,
                     materialLocation.toString(),

--- a/common/src/main/java/com/daqem/grieflogger/mixin/MixinServerPlayer.java
+++ b/common/src/main/java/com/daqem/grieflogger/mixin/MixinServerPlayer.java
@@ -118,6 +118,8 @@ public abstract class MixinServerPlayer extends Player implements GriefLoggerSer
     public void grieflogger$tick(CallbackInfo ci) {
         EnvExecutor.getInEnv(EnvType.SERVER, () -> () -> {
             if (!grieflogger$itemQueue.isEmpty()) {
+                // Ensure the actor's users row exists before logging the item events. (GAP E)
+                Services.USER.ensure(getUUID(), getGameProfile().getName());
                 Services.ITEM.insertMap(getUUID(), level(), blockPosition(), new HashMap<>(grieflogger$itemQueue));
                 grieflogger$itemQueue.clear();
             }


### PR DESCRIPTION

### Fix silently dropped logs when a referenced `levels`/`users` row isn't persisted yet

#### Summary
Logged events can be **silently dropped** when the row they reference in `levels` or `users`
hasn't been written yet - for example the first action in a freshly-loaded dimension (the `levels`
row comes from `LevelLoadEvent`), or a player acting before their `users` row has been flushed.

Each event insert resolves its `NOT NULL` foreign keys (`level`, `user`, `type`) via scalar
sub-selects, e.g. `(SELECT id FROM levels WHERE name = ?)`. If the parent row doesn't exist yet the
sub-select yields `NULL`, the row violates `NOT NULL`, and:

- for **blocks/entities** (`INSERT OR IGNORE` / `INSERT IGNORE`) the row is **discarded with no
  error** - and because the `executeUpdate()` count was ignored, the loss was invisible;
- for **containers/items** (plain `INSERT`) it **throws**, and since the commit in
  `Database.executeStatements` runs only after the loop, the exception **skips the commit for the
  whole flush batch** - losing every event queued that tick, not just the one.

This PR makes those events durable, normalizes a fragile inspect JOIN, and surfaces any residual
drop as a warning. **No schema, command, or config changes; SQLite and MySQL both covered; Fabric
and NeoForge both build.**

#### Changes
1. **Co-enqueue the `levels` parent upsert before the dependent insert**, mirroring what the
   `materials`/`entities` upserts already do, in `BlockRepository`, `ContainerRepository` and
   `ItemRepository`. Because the queue executes in order within one transaction, the level
   sub-select now always resolves.
2. **Ensure the acting player's `users` row before logging their action.** A small
   `Services.USER.ensure(uuid, name)` (`INSERT OR IGNORE INTO users(name, uuid)`) is enqueued at the
   logging sites that have the `ServerPlayer` (block/entity/container/item). It's a cheap idempotent
   ensure-exists - no per-event name rewrite and no username-history row (distinct from
   `insertOrUpdateName`, which is still used on join).
3. **Normalize the position-lookup JOIN.** `BlockRepository.getBlockHistory` /
   `getInteractionHistory` and `ContainerRepository.getHistory` used
   `JOIN levels ON x.level = (SELECT id FROM levels WHERE name = ?)`; these now use
   `JOIN levels ON x.level = levels.id WHERE levels.name = ?`, matching the existing
   `getFilteredBlockHistory`. Clearer and removes a `NULL`-sub-select footgun.
4. **Make drops observable.** Event inserts (blocks/entities/containers/items) are tagged through
   the queue; `Database.executeStatements` now checks the `executeUpdate()` affected-row count and
   logs a warning (with context) when a tagged insert affects **0** rows. Dedup parent upserts
   (`materials`/`levels`/`users`/`entities`), where `0 = already exists`, are untagged and never
   warn.

#### Compatibility / risk
- **No schema or migration** - existing tables and rows are untouched; deploy is a drop-in jar and
  rollback is the previous jar.
- **No command, output, or config changes.**
- **SQLite (default) and MySQL** statement variants kept in parity (only the
  `INSERT OR IGNORE` ↔ `INSERT IGNORE` dialect token differs).
- The extra per-event parent upserts are cheap `INSERT OR IGNORE` no-ops once the row exists -
  identical in spirit to the existing `materials` handling, and amortized by the batch queue.
- Already-lost events are not recoverable; this prevents future loss.

#### Testing
Verified with unit tests against in-memory SQLite (the exact statements the repositories emit are
centralized so they can be exercised without a running server):
- silent-drop **characterization + fix** for a missing `levels`, `users`, `materials` or `entities`
  parent, across **blocks, entity kills, containers and items**;
- the normalized position lookup returns the stored row;
- the drop-warning fires for a tagged event insert that affects 0 rows, and **not** for an untagged
  dedup upsert that affects 0 rows;
- structural parity between the SQLite and MySQL SQL variants.

`./gradlew build` passes for both Fabric and NeoForge.

